### PR TITLE
fix: Do not set a fixed cdk version

### DIFF
--- a/control-plane-addon/package.json
+++ b/control-plane-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keptn/keptn-cp-ssp-addon",
-  "version": "0.0.2",
+  "version": "0.0.0-placeholder",
   "description": "Keptn Control Plane Addon for AWS SSP CDK Platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.135.0",
+    "@aws-cdk/core": "^1.135.0",
     "@aws-quickstart/ssp-amazon-eks": "^0.12.4",
     "@types/async": "3.2.7"
   }

--- a/execution-plane-addon/package.json
+++ b/execution-plane-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keptn/keptn-ep-ssp-addon",
-  "version": "0.0.2",
+  "version": "0.0.0-placeholder",
   "description": "Keptn Execution Plane Addon for AWS SSP CDK Platform",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,7 +31,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "@aws-cdk/core": "1.135.0",
+    "@aws-cdk/core": "^1.135.0",
     "@aws-quickstart/ssp-amazon-eks": "^0.12.4",
     "@types/async": "3.2.7"
   }


### PR DESCRIPTION
Signed-off-by: Christian Heckelmann <christian.heckelmann@dynatrace.com>

- Do not set a fixed CDK Version
- Use a placeholder within the package.json files for version number